### PR TITLE
Fixing DNSMOS implementation for short inputs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = torch_utilities
-version = 1.1.2
+version = 1.1.3
 author = Federico Di Marzo
 author_email = federicodimarzo@protonmail.com
 description = Simplifying audio and deep learning with PyTorch.


### PR DESCRIPTION
With this PR zero padding is added to the input of DNSMOS when it's shorter than 9.01 s (the input size of the model).