### PR TITLE
Using `torch.tensor` instead of `Tensor`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = torch_utilities
-version = 1.2.1
+version = 1.2.2
 author = Federico Di Marzo
 author_email = federicodimarzo@protonmail.com
 description = Simplifying audio and deep learning with PyTorch.

--- a/torch_utilities/io.py
+++ b/torch_utilities/io.py
@@ -129,7 +129,7 @@ def load_audio_parallel(
         _load = lambda x: load_audio(x, sample_rate, False)[0]
         xs = pool.map(_load, file_paths)
     if tensor:
-        xs = [torch.tensor(x, device=device) for x in xs]
+        xs = [torch.tensor(x, device=device, dtype=torch.float32) for x in xs]
     return xs
 
 

--- a/torch_utilities/io.py
+++ b/torch_utilities/io.py
@@ -129,7 +129,7 @@ def load_audio_parallel(
         _load = lambda x: load_audio(x, sample_rate, False)[0]
         xs = pool.map(_load, file_paths)
     if tensor:
-        xs = [Tensor(x, device=device) for x in xs]
+        xs = [torch.tensor(x, device=device) for x in xs]
     return xs
 
 
@@ -166,9 +166,7 @@ def load_audio_parallel_itr(
     file_paths = (x for x in file_paths)
     for i in range(0, n_files, num_workers):
         files_batch = islice(file_paths, num_workers)
-        cache = load_audio_parallel(
-            files_batch, sample_rate, tensor, device, num_workers
-        )
+        cache = load_audio_parallel(files_batch, sample_rate, tensor, device, num_workers)
         for x in cache:
             yield x
 
@@ -238,9 +236,7 @@ def pack_audio_sequences(
         while _sample_left(x) > 0:
             # copying into the sequence
             delta = min(_seq_left(), _sample_left(x))
-            seq[:, seq_ptr : seq_ptr + delta] = x[
-                :channels, sample_ptr : sample_ptr + delta
-            ]
+            seq[:, seq_ptr : seq_ptr + delta] = x[:channels, sample_ptr : sample_ptr + delta]
             seq_ptr += delta
             sample_ptr += delta
 


### PR DESCRIPTION
- Changing the call to `Tensor` to `torch.tensor`